### PR TITLE
Discard io.EOF when more than 0 bytes have been read

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -109,6 +109,10 @@ func (r *Reader) more() {
 	if a == 0 && r.state == nil {
 		r.state = io.ErrNoProgress
 		return
+	} else if a > 0 && r.state == io.EOF {
+		// discard the io.EOF if we read more than 0 bytes.
+		// the next call to Read should return io.EOF again.
+		r.state = nil
 	}
 	r.data = r.data[:len(r.data)+a]
 }


### PR DESCRIPTION
Some `io.Reader` instances can return `io.EOF` with a non-zero number of
bytes and will then return 0 bytes with the `io.EOF` error on the next
read. This interferes with the expectation that `io.EOF` meant that no
bytes had been read.

Discard the error and buffer the read data so these types of `io.Reader`
instances still work properly.

Fixes #13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/philhofer/fwd/14)
<!-- Reviewable:end -->
