### PR TITLE
tinygo support

### DIFF
--- a/writer_tinygo.go
+++ b/writer_tinygo.go
@@ -1,4 +1,4 @@
-// +build !appengine,!tinygo
+// +build tinygo
 
 package fwd
 
@@ -9,7 +9,7 @@ import (
 
 // unsafe cast string as []byte
 func unsafestr(b string) []byte {
-	l := len(b)
+	l := uintptr(len(b))
 	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
 		Len:  l,
 		Cap:  l,


### PR DESCRIPTION
This PR makes `fwd` compile and test correctly with TinyGo.  After some review, I think this change makes more sense than using the not-unsafe version under TinyGo - since unnecessary allocations are particularly problematic in microcontrollers environments.

The actual change is very minor: just one cast from int to uintptr. But I had to copy the function and make a TinyGo-specific version.

For [reasons explained here](https://github.com/tinygo-org/tinygo/issues/1284), reflect.SliceHeader is defined slightly differently in [TinyGo](https://github.com/tinygo-org/tinygo/blob/release/src/reflect/value.go#L742) vs [Go](https://github.com/golang/go/blob/master/src/reflect/value.go#L2335). 

The tests now pass in TinyGo with:

```
GO111MODULE=off tinygo test .
```

Or if you have Docker installed but not TinyGo, you can do:

```
docker run --rm -v $(pwd):/src -e GO111MODULE=off tinygo/tinygo:latest bash -c 'cd /src/ && tinygo test .'
```
