### PR TITLE
Fix panic in Reader.more() 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -129,6 +129,8 @@ func (r *Reader) more() {
 		// discard the io.EOF if we read more than 0 bytes.
 		// the next call to Read should return io.EOF again.
 		r.state = nil
+	} else if r.state != nil {
+		return
 	}
 	r.data = r.data[:len(r.data)+a]
 }


### PR DESCRIPTION
Fix panic in Reader.more() because of an unchecked error from the underlying reader.

Fixes https://github.com/philhofer/fwd/issues/25