### PR TITLE
unsafestr: update to use unsafe.Slice()

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ the write position by the length of the returned slice. This allows users
 to write directly to the end of the buffer.
 
 
+## Portability
+
+Because it uses the unsafe package, there are theoretically
+no promises about forward or backward portability.
+
+To stay compatible with tinygo 0.32, unsafestr() has been updated
+to use unsafe.Slice() as suggested by
+https://tinygo.org/docs/guides/compatibility, which also required
+bumping go.mod to require at least go 1.20.
 
 
 ## <a name="pkg-index">Index</a>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/philhofer/fwd
 
-go 1.15
+go 1.20 // unsafe.StringData requires go1.20 or later

--- a/writer_tinygo.go
+++ b/writer_tinygo.go
@@ -4,16 +4,10 @@
 package fwd
 
 import (
-	"reflect"
 	"unsafe"
 )
 
 // unsafe cast string as []byte
 func unsafestr(b string) []byte {
-	l := uintptr(len(b))
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Len:  l,
-		Cap:  l,
-		Data: (*reflect.StringHeader)(unsafe.Pointer(&b)).Data,
-	}))
+	return unsafe.Slice(unsafe.StringData(b), len(b))
 }


### PR DESCRIPTION
Adds support for tinygo 0.32, thereby fixing https://github.com/philhofer/fwd/issues/29

Passes tests on macos intel:
- go 1.21.9:
	- go test
- go 1.21.9 / tinygo 0.32 prerelease:
	- tinygo test
	- tinygo test -target wasi