### PR TITLE
Added Reader.InputOffset

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -82,9 +82,10 @@ type Reader struct {
 	r io.Reader // underlying reader
 
 	// data[n:len(data)] is buffered data; data[len(data):cap(data)] is free buffer space
-	data  []byte // data
-	n     int    // read offset
-	state error  // last read error
+	data        []byte // data
+	n           int    // read offset
+	inputOffset int    // offset in the input stream
+	state       error  // last read error
 
 	// if the reader past to NewReader was
 	// also an io.Seeker, this is non-nil
@@ -97,6 +98,7 @@ func (r *Reader) Reset(rd io.Reader) {
 	r.r = rd
 	r.data = r.data[0:0]
 	r.n = 0
+	r.inputOffset = 0
 	r.state = nil
 	if s, ok := rd.(io.Seeker); ok {
 		r.rs = s
@@ -158,6 +160,9 @@ func (r *Reader) Buffered() int { return len(r.data) - r.n }
 // BufferSize returns the total size of the buffer
 func (r *Reader) BufferSize() int { return cap(r.data) }
 
+// InputOffset returns the input stream byte offset of the current reader position
+func (r *Reader) InputOffset() int { return r.inputOffset }
+
 // Peek returns the next 'n' buffered bytes,
 // reading from the underlying reader if necessary.
 // It will only return a slice shorter than 'n' bytes
@@ -197,10 +202,12 @@ func (r *Reader) discard(n int) int {
 	inbuf := r.buffered()
 	if inbuf <= n {
 		r.n = 0
+		r.inputOffset += inbuf
 		r.data = r.data[:0]
 		return inbuf
 	}
 	r.n += n
+	r.inputOffset += n
 	return n
 }
 
@@ -228,6 +235,7 @@ func (r *Reader) Skip(n int) (int, error) {
 	// if we can Seek() through the remaining bytes, do that
 	if n > skipped && r.rs != nil {
 		nn, err := r.rs.Seek(int64(n-skipped), 1)
+		r.inputOffset += int(nn)
 		return int(nn) + skipped, err
 	}
 	// otherwise, keep filling the buffer
@@ -267,6 +275,7 @@ func (r *Reader) Next(n int) ([]byte, error) {
 	}
 	out := r.data[r.n : r.n+n]
 	r.n += n
+	r.inputOffset += n
 	return out, nil
 }
 
@@ -277,6 +286,7 @@ func (r *Reader) Read(b []byte) (int, error) {
 	if r.buffered() != 0 {
 		x := copy(b, r.data[r.n:])
 		r.n += x
+		r.inputOffset += x
 		return x, nil
 	}
 	var n int
@@ -293,6 +303,9 @@ func (r *Reader) Read(b []byte) (int, error) {
 	if n == 0 {
 		return 0, r.err()
 	}
+
+	r.inputOffset += n
+
 	return n, nil
 }
 
@@ -312,9 +325,11 @@ func (r *Reader) ReadFull(b []byte) (int, error) {
 			nn = copy(b[n:], r.data[r.n:])
 			n += nn
 			r.n += nn
+			r.inputOffset += nn
 		} else if l-n > cap(r.data) {
 			nn, r.state = r.r.Read(b[n:])
 			n += nn
+			r.inputOffset += nn
 		} else {
 			r.more()
 		}
@@ -335,6 +350,8 @@ func (r *Reader) ReadByte() (byte, error) {
 	}
 	b := r.data[r.n]
 	r.n++
+	r.inputOffset++
+
 	return b, nil
 }
 
@@ -354,6 +371,7 @@ func (r *Reader) WriteTo(w io.Writer) (int64, error) {
 		}
 		r.data = r.data[0:0]
 		r.n = 0
+		r.inputOffset += ii
 	}
 	for r.state == nil {
 		// here we just do
@@ -367,6 +385,7 @@ func (r *Reader) WriteTo(w io.Writer) (int64, error) {
 			}
 			r.data = r.data[0:0]
 			r.n = 0
+			r.inputOffset += ii
 		}
 	}
 	if r.state != io.EOF {

--- a/reader_test.go
+++ b/reader_test.go
@@ -424,7 +424,7 @@ func TestInputOffset(t *testing.T) {
 
 	n, _ := rd.Read(make([]byte, 128))
 
-	if rd.InputOffset() != 385+n {
+	if rd.InputOffset() != int64(385+n) {
 		t.Errorf("expected offset %d; got %d", 385+n, rd.InputOffset())
 	}
 
@@ -439,6 +439,25 @@ func TestInputOffset(t *testing.T) {
 	if err != io.EOF {
 		t.Fatalf("expected error %q; got %q", io.EOF, err)
 	}
+
+	if rd.InputOffset() != 1024 {
+		t.Errorf("expected offset 1024; got %d", rd.InputOffset())
+	}
+
+	// reset the reader
+	rd.Reset(bytes.NewReader(bts))
+
+	if rd.InputOffset() != 0 {
+		t.Errorf("expected offset 0; got %d", rd.InputOffset())
+	}
+
+	rd.Skip(768 + 32)
+
+	if rd.InputOffset() != 800 {
+		t.Errorf("expected offset 800; got %d", rd.InputOffset())
+	}
+
+	rd.WriteTo(ioutil.Discard)
 
 	if rd.InputOffset() != 1024 {
 		t.Errorf("expected offset 1024; got %d", rd.InputOffset())

--- a/reader_test.go
+++ b/reader_test.go
@@ -382,6 +382,69 @@ func TestReadFull(t *testing.T) {
 	}
 }
 
+func TestInputOffset(t *testing.T) {
+	bts := randomBts(1024)
+	rd := NewReaderSize(partialReader{bytes.NewReader(bts)}, 128)
+
+	if rd.InputOffset() != 0 {
+		t.Errorf("expected offset 0; got %d", rd.InputOffset())
+	}
+
+	// read a few bytes
+	rd.ReadFull(make([]byte, 10))
+
+	if rd.InputOffset() != 10 {
+		t.Errorf("expected offset 10; got %d", rd.InputOffset())
+	}
+
+	rd.Peek(384)
+
+	// peeking doesn't advance the offset
+	if rd.InputOffset() != 10 {
+		t.Errorf("expected offset 10; got %d", rd.InputOffset())
+	}
+
+	rd.Next(246)
+
+	if rd.InputOffset() != 256 {
+		t.Errorf("expected offset 256; got %d", rd.InputOffset())
+	}
+
+	rd.Skip(128)
+
+	if rd.InputOffset() != 384 {
+		t.Errorf("expected offset 384; got %d", rd.InputOffset())
+	}
+
+	rd.ReadByte()
+
+	if rd.InputOffset() != 385 {
+		t.Errorf("expected offset 385; got %d", rd.InputOffset())
+	}
+
+	n, _ := rd.Read(make([]byte, 128))
+
+	if rd.InputOffset() != 385+n {
+		t.Errorf("expected offset %d; got %d", 385+n, rd.InputOffset())
+	}
+
+	rd.WriteTo(ioutil.Discard)
+
+	if rd.InputOffset() != 1024 {
+		t.Errorf("expected offset 1024; got %d", rd.InputOffset())
+	}
+
+	// try to read more
+	_, err := rd.Read(make([]byte, 32))
+	if err != io.EOF {
+		t.Fatalf("expected error %q; got %q", io.EOF, err)
+	}
+
+	if rd.InputOffset() != 1024 {
+		t.Errorf("expected offset 1024; got %d", rd.InputOffset())
+	}
+}
+
 type readCounter struct {
 	r     io.Reader
 	count int


### PR DESCRIPTION
This adds Reader.InputOffset, modelled after json.Decoder.InputOffset, which keeps track of byte offset in the input stream. (we're planning to use this from tinylib/msgp)